### PR TITLE
Update version to 3.12.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,67 @@
-python3-defaults (3.12.1-1deepin1) unstable; urgency=medium
+python3-defaults (3.12.8-1) unstable; urgency=medium
 
-  * Disable python3.11 build.
+  * Bump version to 3.12.8
+  * Update python3-supported-max (missed in 3.12.7-1).
+  * Add a check that python3-supported-(min|max) is correct.
+  * Re-enable check_versions at build time.
 
- -- xiangzelong <xiangzelong@deepin.org>  Wed, 04 Sep 2024 14:50:36 +0800
+ -- Stefano Rivera <stefanor@debian.org>  Mon, 23 Dec 2024 15:15:27 -0400
+
+python3-defaults (3.12.7-1) unstable; urgency=medium
+
+  [ Matthias Klose ]
+  * Bump version to 3.12.7
+
+  [ Stefano Rivera ]
+  * Add 3.13 as a supported Python3 version.
+
+ -- Matthias Klose <doko@debian.org>  Wed, 13 Nov 2024 06:53:11 +0100
+
+python3-defaults (3.12.6-1) unstable; urgency=medium
+
+  * Bump version to 3.12.6
+  * 2to3: Remove obsolete breaks/replaces.
+  * Make python3 maintainer scripts more robust for runtime updates.
+    LP: #2078356.
+
+ -- Matthias Klose <doko@debian.org>  Mon, 16 Sep 2024 17:21:13 +0200
+
+python3-defaults (3.12.5-1) unstable; urgency=medium
+
+  * Bump version to 3.12.5
+  * debpython/files.py: Set LC_ALL="C.UTF-8" before calling dpkg -L to avoid
+    localization issues (LP: #2075337)
+  * Bump standards version.
+
+ -- Matthias Klose <doko@debian.org>  Thu, 08 Aug 2024 07:30:33 +0200
+
+python3-defaults (3.12.4-1) unstable; urgency=medium
+
+  * Bump version to 3.12.4
+  * python3: Conflict with python3-distutils.
+
+ -- Matthias Klose <doko@debian.org>  Sat, 20 Jul 2024 11:46:46 +0200
+
+python3-defaults (3.12.3-1) unstable; urgency=medium
+
+  * Bump version to 3.12.3
+  * Drop dependencies on python3-distutils.
+  * Remove Python 3.11 as a supported version.
+
+ -- Matthias Klose <doko@debian.org>  Tue, 09 Jul 2024 13:01:35 +0200
+
+python3-defaults (3.12.2-1) unstable; urgency=medium
+
+  [ Stefano Rivera ]
+  * Migrate to html2text 2.x, which dropped the -pretty flag.
+    Closes: #1064737.
+  * Fix typo in py3clean manpage. Thanks JT Hundley. Closes: #1070728.
+
+  [ Matthias Klose ]
+  * Bump version.
+  * Depend on libpython3.XYt64-dbg, tighten python3.12 build dependency.
+
+ -- Matthias Klose <doko@debian.org>  Mon, 24 Jun 2024 10:23:35 +0200
 
 python3-defaults (3.12.1-1) experimental; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Section: python
 Priority: optional
 Maintainer: Matthias Klose <doko@debian.org>
 Uploaders: Piotr Ożarowski <piotr@debian.org>, Stefano Rivera <stefanor@debian.org>
-Build-Depends: debhelper (>= 11), dpkg-dev (>= 1.17.11), python3.12:any (>= 3.12.1-2~),
+Build-Depends: debhelper (>= 11), dpkg-dev (>= 1.17.11), python3.12:any (>= 3.12.7-1~),
   python3.12-minimal:any,
   python3-docutils <!nodoc>,
   python3-sphinx <!nodoc>,
-  html2text <!nodoc>,
-Standards-Version: 4.6.2
+  html2text (>= 2) <!nodoc>,
+Standards-Version: 4.7.0
 Homepage: https://www.python.org/
 Vcs-Git: https://salsa.debian.org/cpython-team/python3-defaults.git
 Vcs-Browser: https://salsa.debian.org/cpython-team/python3-defaults
@@ -17,10 +17,11 @@ Package: python3
 Architecture: any
 Multi-Arch: allowed
 Pre-Depends: python3-minimal (= ${binary:Version})
-Depends: python3.12 (>= 3.12.1-2~), libpython3-stdlib (= ${binary:Version}), ${misc:Depends}
-Suggests: python3-doc (>= ${binary:Version}), python3-tk (>= 3.11.5-1~) , python3-venv (>= ${binary:Version})
+Depends: python3.12 (>= 3.12.7-1~), libpython3-stdlib (= ${binary:Version}), ${misc:Depends}
+Suggests: python3-doc (>= ${binary:Version}), python3-tk (>= 3.12.7-1~) , python3-venv (>= ${binary:Version})
 Replaces: python3-minimal (<< 3.1.2-2)
-Provides: python3-profiler, python3-supported-min (= 3.11), python3-supported-max (= 3.12)
+Provides: python3-profiler, python3-supported-min (= 3.12), python3-supported-max (= 3.13)
+Conflicts: python3-distutils
 Description: interactive high-level object-oriented language (default python3 version)
  Python, the high-level, interactive object oriented language,
  includes an extensive class library with lots of goodies for
@@ -32,8 +33,8 @@ Description: interactive high-level object-oriented language (default python3 ve
 Package: python3-venv
 Architecture: any
 Multi-Arch: allowed
-Depends: python3.12-venv (>= 3.12.1-2~), python3 (= ${binary:Version}),
-  python3-distutils (>= 3.11.5-1~), ${misc:Depends}
+Depends: python3.12-venv (>= 3.12.7-1~), python3 (= ${binary:Version}),
+  ${misc:Depends}
 Description: venv module for python3 (default python3 version)
  This package contains the venv module for the Python language (default python3
  version).
@@ -51,7 +52,7 @@ Description: venv module for python3 (default python3 version)
 Package: python3-minimal
 Architecture: any
 Multi-Arch: allowed
-Pre-Depends: python3.12-minimal (>= 3.12.1-2~)
+Pre-Depends: python3.12-minimal (>= 3.12.7-1~)
 Depends: dpkg (>= 1.13.20), ${misc:Depends}
 Description: minimal subset of the Python language (default python3 version)
  This package contains the interpreter and some essential modules.  It's used
@@ -64,7 +65,7 @@ Package: python3-nopie
 Architecture: any
 Multi-Arch: allowed
 Depends: python3 (= ${binary:Version}),
-  python3.12-nopie (>= 3.12.1-2~), ${misc:Depends}
+  python3.12-nopie (>= 3.12.7-1~), ${misc:Depends}
 Description: Python interpreter linked without PIE (default python3 version)
  This package contains the interpreter not built as position independent
  executable. This interpreter is diverting the python3 executable, and making
@@ -74,7 +75,7 @@ XB-Cnf-Visible-Pkgname: python3
 Package: python3-examples
 Architecture: all
 Multi-Arch: foreign
-Depends: python3 (>= ${binary:Version}), python3.12-examples (>= 3.12.1-2~), ${misc:Depends}
+Depends: python3 (>= ${binary:Version}), python3.12-examples (>= 3.12.7-1~), ${misc:Depends}
 Description: examples for the Python language (default version)
  Examples, Demos and Tools for Python. These are files included in
  the upstream Python distribution.
@@ -86,7 +87,7 @@ Package: python3-dev
 Architecture: any
 Multi-Arch: allowed
 Depends: python3 (= ${binary:Version}), libpython3-dev (= ${binary:Version}),
-  python3.12-dev (>= 3.12.1-2~), python3-distutils (>= 3.11.5-1~),
+  python3.12-dev (>= 3.12.7-1~),
   ${misc:Depends}, ${sphinxdoc:Depends}
 Breaks: python3 (<< 3.9.2-1~)
 Replaces: python3.1 (<< 3.1.2+20100706-3), python3 (<< 3.9.2-1~)
@@ -103,7 +104,7 @@ Package: libpython3-dev
 Architecture: any
 Multi-Arch: same
 Section: libdevel
-Depends: libpython3.12-dev (>= 3.12.1-2~), ${misc:Depends}
+Depends: libpython3.12-dev (>= 3.12.7-1~), ${misc:Depends}
 Breaks: libpython3.8-dev (<< 3.8.0-2), python3-dev (<< 3.8.0-1)
 Replaces: libpython3.8-dev (<< 3.8.0-2), python3-dev (<< 3.8.0-1)
 Description: header files and a static library for Python (default)
@@ -117,7 +118,7 @@ Description: header files and a static library for Python (default)
 Package: libpython3-stdlib
 Architecture: any
 Multi-Arch: same
-Depends: libpython3.12-stdlib (>= 3.12.1-2~), ${misc:Depends}
+Depends: libpython3.12-stdlib (>= 3.12.7-1~), ${misc:Depends}
 Description: interactive high-level object-oriented language (default python3 version)
  This package contains the majority of the standard library for the Python
  language (default python3 version).
@@ -142,7 +143,7 @@ Package: python3-doc
 Section: doc
 Architecture: all
 Multi-Arch: foreign
-Depends: python3.12-doc (>= 3.12.1-2~), ${misc:Depends}
+Depends: python3.12-doc (>= 3.12.7-1~), ${misc:Depends}
 Suggests: python3 (>= ${binary:Version}), python3-examples
 Description: documentation for the high-level object-oriented language Python 3
  This is the official set of documentation for the interactive high-level
@@ -166,7 +167,7 @@ Package: python3-dbg
 Architecture: any
 Multi-Arch: allowed
 Section: debug
-Depends: python3 (= ${binary:Version}), libpython3-dbg (= ${binary:Version}), python3.12-dbg (>= 3.12.1-2~), ${misc:Depends}
+Depends: python3 (= ${binary:Version}), libpython3-dbg (= ${binary:Version}), python3.12-dbg (>= 3.12.7-1~), ${misc:Depends}
 Description: debug build of the Python 3 Interpreter (version 3.12)
  Python 3 interpreter configured with --pydebug. Dynamically loaded modules
  are searched in /usr/lib/python3.12/lib-dynload/debug first.
@@ -175,7 +176,7 @@ Package: libpython3-dbg
 Architecture: any
 Multi-Arch: same
 Section: debug
-Depends: libpython3.12-dbg (>= 3.12.1-2~), ${misc:Depends}
+Depends: libpython3.12t64-dbg (>= 3.12.7-1~), ${misc:Depends}
 Breaks: python3-dbg (<< 3.8.0-1)
 Replaces: python3-dbg (<< 3.8.0-1)
 Description: debug build of the Python 3 Interpreter (version 3.12)
@@ -187,12 +188,12 @@ Architecture: any
 Multi-Arch: allowed
 Depends: python3 (= ${binary:Version}),
  ${misc:Depends},
- python3-distutils (>= 3.11.5-1~),
- python3.11,
  python3.12,
+ python3.13,
 Description: package depending on all supported Python 3 runtime versions
- The package currently depends on python3.11 and python3.12, in the future, dependencies on
- jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12 and python3.13. In the future,
+ dependencies on jython (Python for a JVM) and ironpython (Python for Mono) may
+ be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 runtimes.
@@ -205,11 +206,12 @@ Depends: python3 (= ${binary:Version}),
  python3-all (= ${binary:Version}),
  python3-dev (= ${binary:Version}),
  ${misc:Depends},
- python3.11-dev,
  python3.12-dev,
+ python3.13-dev,
 Description: package depending on all supported Python 3 development packages
- The package currently depends on python3.11-dev and python3.12-dev, in the future, dependencies
- on jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12-dev and python3.13-dev. In the
+ future, dependencies on jython (Python for a JVM) and ironpython (Python for
+ Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 development
@@ -224,11 +226,12 @@ Depends: python3 (= ${binary:Version}),
  python3-all (= ${binary:Version}),
  python3-dbg (= ${binary:Version}),
  ${misc:Depends},
- python3.11-dbg,
  python3.12-dbg,
+ python3.13-dbg,
 Description: package depending on all supported Python 3 debugging packages
- The package currently depends on python3.11-dbg and python3.12-dbg, in the future, dependencies
- on jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12-dbg and python3.13-dbg. In the
+ future, dependencies on jython (Python for a JVM) and ironpython (Python for
+ Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 debug packages.
@@ -240,11 +243,12 @@ Depends: python3 (= ${binary:Version}),
  python3-all (= ${binary:Version}),
  python3-venv (= ${binary:Version}),
  ${misc:Depends},
- python3.11-venv,
  python3.12-venv,
+ python3.13-venv,
 Description: package depending on all supported Python 3 venv modules
- The package currently depends on python3.11-venv and python3.12-venv, in the future, dependencies
- on jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12-venv and python3.13-venv. In the
+ future, dependencies on jython (Python for a JVM) and ironpython (Python for
+ Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 venv packages.
@@ -255,12 +259,12 @@ Multi-Arch: same
 Section: libdevel
 Depends: libpython3-dev (= ${binary:Version}),
  ${misc:Depends},
- libpython3.11-dev,
  libpython3.12-dev,
+ libpython3.13-dev,
 Description: package depending on all supported Python 3 development packages
- The package currently depends on libpython3.11-dev and libpython3.12-dev, in the future,
- dependencies on jython (Python for a JVM) and ironpython (Python for Mono) may
- be added.
+ The package currently depends on libpython3.12-dev and libpython3.13-dev. In
+ the future, dependencies on jython (Python for a JVM) and ironpython (Python
+ for Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 development
@@ -272,12 +276,12 @@ Multi-Arch: same
 Section: debug
 Depends: libpython3-dbg (= ${binary:Version}),
  ${misc:Depends},
- libpython3.11-dbg,
- libpython3.12-dbg,
+ libpython3.12t64-dbg,
+ libpython3.13-dbg,
 Description: package depending on all supported Python 3 debugging packages
- The package currently depends on libpython3.11-dbg and libpython3.12-dbg, in the future,
- dependencies on jython (Python for a JVM) and ironpython (Python for Mono) may
- be added.
+ The package currently depends on libpython3.12-dbg and libpython3.13-dbg. In
+ the future, dependencies on jython (Python for a JVM) and ironpython (Python
+ for Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 debug packages.
@@ -285,9 +289,7 @@ Description: package depending on all supported Python 3 debugging packages
 Package: 2to3
 Architecture: all
 Multi-Arch: foreign
-Depends: python3-lib2to3 (>= 3.11.5-1~), python3 (>= ${binary:Version}), ${misc:Depends}
-Breaks: python (<< 2.7.14-4)
-Replaces: python (<< 2.7.14-4)
+Depends: python3-lib2to3 (>= 3.12.7-1~), python3 (>= ${binary:Version}), ${misc:Depends}
 Description: 2to3 binary using python3
  2to3 is a Python program that reads Python 2.x source code and applies a
  series of fixers to transform it into valid Python 3.x code. The standard
@@ -303,11 +305,10 @@ Package: python3-full
 Architecture: any
 Multi-Arch: allowed
 Depends: python3 (= ${binary:Version}),
-  python3.12-full (>= 3.12.1-2~),
+  python3.12-full (>= 3.12.7-1~),
   python3-venv (= ${binary:Version}),
   2to3,
   idle,
-  python3-distutils,
   python3-gdbm,
   python3-lib2to3,
   python3-tk,
@@ -321,7 +322,7 @@ Description: Default Python Interpreter with complete class library
  .
  This package is a dependency package, which depends on the full
  standard library of Python for Python developers. Including modules
- used only at build-time, such as venv and distutils, and modules with
+ used only at build-time, such as venv, and modules with
  complex dependencies, such as tk and IDLE. All batteries included.
  .
  This package depends on Debian's default python 3 version's full

--- a/debian/control
+++ b/debian/control
@@ -176,7 +176,7 @@ Package: libpython3-dbg
 Architecture: any
 Multi-Arch: same
 Section: debug
-Depends: libpython3.12t64-dbg (>= 3.12.7-1~), ${misc:Depends}
+Depends: libpython3.12-dbg (>= 3.12.7-1~), ${misc:Depends}
 Breaks: python3-dbg (<< 3.8.0-1)
 Replaces: python3-dbg (<< 3.8.0-1)
 Description: debug build of the Python 3 Interpreter (version 3.12)
@@ -276,7 +276,7 @@ Multi-Arch: same
 Section: debug
 Depends: libpython3-dbg (= ${binary:Version}),
  ${misc:Depends},
- libpython3.12t64-dbg,
+ libpython3.12-dbg,
  libpython3.13-dbg,
 Description: package depending on all supported Python 3 debugging packages
  The package currently depends on libpython3.12-dbg and libpython3.13-dbg. In

--- a/debian/control.in
+++ b/debian/control.in
@@ -176,7 +176,7 @@ Package: libpython3-dbg
 Architecture: any
 Multi-Arch: same
 Section: debug
-Depends: libpython@VER@t64-dbg (>= @UPSTRVER@), ${misc:Depends}
+Depends: libpython@VER@-dbg (>= @UPSTRVER@), ${misc:Depends}
 Breaks: python3-dbg (<< 3.8.0-1)
 Replaces: python3-dbg (<< 3.8.0-1)
 Description: debug build of the Python 3 Interpreter (version @VER@)
@@ -276,7 +276,7 @@ Multi-Arch: same
 Section: debug
 Depends: libpython3-dbg (= ${binary:Version}),
  ${misc:Depends},
- libpython3.12t64-dbg,
+ libpython3.12-dbg,
  libpython3.13-dbg,
 Description: package depending on all supported Python 3 debugging packages
  The package currently depends on libpython3.12-dbg and libpython3.13-dbg. In

--- a/debian/control.in
+++ b/debian/control.in
@@ -7,8 +7,8 @@ Build-Depends: debhelper (>= 11), @bd_i586@
   python@VER@-minimal:any,
   python3-docutils <!nodoc>,
   python3-sphinx <!nodoc>,
-  html2text <!nodoc>,
-Standards-Version: 4.6.2
+  html2text (>= 2) <!nodoc>,
+Standards-Version: 4.7.0
 Homepage: https://www.python.org/
 Vcs-Git: https://salsa.debian.org/cpython-team/python3-defaults.git
 Vcs-Browser: https://salsa.debian.org/cpython-team/python3-defaults
@@ -20,7 +20,8 @@ Pre-Depends: python3-minimal (= ${binary:Version})
 Depends: python@VER@ (>= @UPSTRVER@), libpython3-stdlib (= ${binary:Version}), ${misc:Depends}
 Suggests: python3-doc (>= ${binary:Version}), python3-tk (>= @STDLIBVER@) , python3-venv (>= ${binary:Version})
 Replaces: python3-minimal (<< 3.1.2-2)
-Provides: python3-profiler, python3-supported-min (= 3.11), python3-supported-max (= 3.12)
+Provides: python3-profiler, python3-supported-min (= 3.12), python3-supported-max (= 3.13)
+Conflicts: python3-distutils
 Description: interactive high-level object-oriented language (default python3 version)
  Python, the high-level, interactive object oriented language,
  includes an extensive class library with lots of goodies for
@@ -33,7 +34,7 @@ Package: python3-venv
 Architecture: any
 Multi-Arch: allowed
 Depends: python@VER@-venv (>= @UPSTRVER@), python3 (= ${binary:Version}),
-  python3-distutils (>= @STDLIBVER@), ${misc:Depends}
+  ${misc:Depends}
 Description: venv module for python3 (default python3 version)
  This package contains the venv module for the Python language (default python3
  version).
@@ -86,7 +87,7 @@ Package: python3-dev
 Architecture: any
 Multi-Arch: allowed
 Depends: python3 (= ${binary:Version}), libpython3-dev (= ${binary:Version}),
-  python@VER@-dev (>= @UPSTRVER@), python3-distutils (>= @STDLIBVER@),
+  python@VER@-dev (>= @UPSTRVER@),
   ${misc:Depends}, ${sphinxdoc:Depends}
 Breaks: python3 (<< 3.9.2-1~)
 Replaces: python3.1 (<< 3.1.2+20100706-3), python3 (<< 3.9.2-1~)
@@ -175,7 +176,7 @@ Package: libpython3-dbg
 Architecture: any
 Multi-Arch: same
 Section: debug
-Depends: libpython@VER@-dbg (>= @UPSTRVER@), ${misc:Depends}
+Depends: libpython@VER@t64-dbg (>= @UPSTRVER@), ${misc:Depends}
 Breaks: python3-dbg (<< 3.8.0-1)
 Replaces: python3-dbg (<< 3.8.0-1)
 Description: debug build of the Python 3 Interpreter (version @VER@)
@@ -187,12 +188,12 @@ Architecture: any
 Multi-Arch: allowed
 Depends: python3 (= ${binary:Version}),
  ${misc:Depends},
- python3-distutils (>= @STDLIBVER@),
- python3.11,
  python3.12,
+ python3.13,
 Description: package depending on all supported Python 3 runtime versions
- The package currently depends on python3.11 and python3.12, in the future, dependencies on
- jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12 and python3.13. In the future,
+ dependencies on jython (Python for a JVM) and ironpython (Python for Mono) may
+ be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 runtimes.
@@ -205,11 +206,12 @@ Depends: python3 (= ${binary:Version}),
  python3-all (= ${binary:Version}),
  python3-dev (= ${binary:Version}),
  ${misc:Depends},
- python3.11-dev,
  python3.12-dev,
+ python3.13-dev,
 Description: package depending on all supported Python 3 development packages
- The package currently depends on python3.11-dev and python3.12-dev, in the future, dependencies
- on jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12-dev and python3.13-dev. In the
+ future, dependencies on jython (Python for a JVM) and ironpython (Python for
+ Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 development
@@ -224,11 +226,12 @@ Depends: python3 (= ${binary:Version}),
  python3-all (= ${binary:Version}),
  python3-dbg (= ${binary:Version}),
  ${misc:Depends},
- python3.11-dbg,
  python3.12-dbg,
+ python3.13-dbg,
 Description: package depending on all supported Python 3 debugging packages
- The package currently depends on python3.11-dbg and python3.12-dbg, in the future, dependencies
- on jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12-dbg and python3.13-dbg. In the
+ future, dependencies on jython (Python for a JVM) and ironpython (Python for
+ Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 debug packages.
@@ -240,11 +243,12 @@ Depends: python3 (= ${binary:Version}),
  python3-all (= ${binary:Version}),
  python3-venv (= ${binary:Version}),
  ${misc:Depends},
- python3.11-venv,
  python3.12-venv,
+ python3.13-venv,
 Description: package depending on all supported Python 3 venv modules
- The package currently depends on python3.11-venv and python3.12-venv, in the future, dependencies
- on jython (Python for a JVM) and ironpython (Python for Mono) may be added.
+ The package currently depends on python3.12-venv and python3.13-venv. In the
+ future, dependencies on jython (Python for a JVM) and ironpython (Python for
+ Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 venv packages.
@@ -255,12 +259,12 @@ Multi-Arch: same
 Section: libdevel
 Depends: libpython3-dev (= ${binary:Version}),
  ${misc:Depends},
- libpython3.11-dev,
  libpython3.12-dev,
+ libpython3.13-dev,
 Description: package depending on all supported Python 3 development packages
- The package currently depends on libpython3.11-dev and libpython3.12-dev, in the future,
- dependencies on jython (Python for a JVM) and ironpython (Python for Mono) may
- be added.
+ The package currently depends on libpython3.12-dev and libpython3.13-dev. In
+ the future, dependencies on jython (Python for a JVM) and ironpython (Python
+ for Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 development
@@ -272,12 +276,12 @@ Multi-Arch: same
 Section: debug
 Depends: libpython3-dbg (= ${binary:Version}),
  ${misc:Depends},
- libpython3.11-dbg,
- libpython3.12-dbg,
+ libpython3.12t64-dbg,
+ libpython3.13-dbg,
 Description: package depending on all supported Python 3 debugging packages
- The package currently depends on libpython3.11-dbg and libpython3.12-dbg, in the future,
- dependencies on jython (Python for a JVM) and ironpython (Python for Mono) may
- be added.
+ The package currently depends on libpython3.12-dbg and libpython3.13-dbg. In
+ the future, dependencies on jython (Python for a JVM) and ironpython (Python
+ for Mono) may be added.
  .
  This package is a dependency package used as a build dependency for other
  packages to avoid hardcoded dependencies on specific Python 3 debug packages.
@@ -286,8 +290,6 @@ Package: 2to3
 Architecture: all
 Multi-Arch: foreign
 Depends: python3-lib2to3 (>= @STDLIBVER@), python3 (>= ${binary:Version}), ${misc:Depends}
-Breaks: python (<< 2.7.14-4)
-Replaces: python (<< 2.7.14-4)
 Description: 2to3 binary using python3
  2to3 is a Python program that reads Python 2.x source code and applies a
  series of fixers to transform it into valid Python 3.x code. The standard
@@ -307,7 +309,6 @@ Depends: python3 (= ${binary:Version}),
   python3-venv (= ${binary:Version}),
   2to3,
   idle,
-  python3-distutils,
   python3-gdbm,
   python3-lib2to3,
   python3-tk,
@@ -321,7 +322,7 @@ Description: Default Python Interpreter with complete class library
  .
  This package is a dependency package, which depends on the full
  standard library of Python for Python developers. Including modules
- used only at build-time, such as venv and distutils, and modules with
+ used only at build-time, such as venv, and modules with
  complex dependencies, such as tk and IDLE. All batteries included.
  .
  This package depends on Debian's default python 3 version's full

--- a/debian/debian_defaults
+++ b/debian/debian_defaults
@@ -3,7 +3,7 @@
 default-version = python3.12
 
 # all supported python3 versions
-supported-versions = python3.12
+supported-versions = python3.12, python3.13
 
 # formerly supported python3 versions
 old-versions = python3.1, python3.2, python3.3, python3.4, python3.5, python3.6, python3.7, python3.8, python3.9, python3.10, python3.11

--- a/debian/python3.postinst.in
+++ b/debian/python3.postinst.in
@@ -12,6 +12,7 @@ new_config_file()
 
 case "$1" in
     configure)
+	_py_errors=
 	[ -d /etc/python3 ] || mkdir /etc/python3
 	[ -f /etc/python3/debian_config ] || new_config_file
 
@@ -24,10 +25,10 @@ case "$1" in
 	    if ! $hook rtupdate python$oldv @PVER@; then
 	        hb=$(basename $hook .rtupdate)
 	        echo >&2 "error running python rtupdate hook $hb"
-	        errors=yes
+	        _py_errors=yes
 	    fi
 	done
-	[ -z "$errors" ] || exit 4
+	[ -z "$_py_errors" ] || exit 4
 
 	if [ "$DEBIAN_FRONTEND" != noninteractive ]; then
 	    echo "running python post-rtupdate hooks for @PVER@..."
@@ -37,10 +38,10 @@ case "$1" in
 	    if ! $hook post-rtupdate python$oldv @PVER@; then
 	        hb=$(basename $hook .rtupdate)
 	        echo >&2 "error running python post-rtupdate hook $hb"
-	        errors=yes
+	        _py_errors=yes
 	    fi
 	done
-	[ -z "$errors" ] || exit 5
+	[ -z "$_py_errors" ] || exit 5
 esac
 
 if which py3compile >/dev/null 2>&1; then

--- a/debian/python3.preinst.in
+++ b/debian/python3.preinst.in
@@ -9,6 +9,7 @@ update-alternatives --auto /usr/bin/python3 >/dev/null 2>&1 || true
 
 case "$1" in
     upgrade)
+	_py_errors=
 	oldv=$(echo $2 | sed 's/^\(...\).*/\1/')
 	if [ "$DEBIAN_FRONTEND" != noninteractive ]; then
 	    echo "running python pre-rtupdate hooks for @PVER@..."
@@ -20,11 +21,11 @@ case "$1" in
 		echo >&2 "error running python pre-rtupdate hook $hb"
 		echo >&2 "running python failed-pre-rtupdate hook $hb"
 		$hook failed-pre-rtupdate python$oldv @PVER@
-		errors=yes
+		_py_errors=yes
 		break
 	    fi
 	done
-	[ -z "$errors" ] || exit 3
+	[ -z "$_py_errors" ] || exit 3
 esac
 
 #DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -21,13 +21,13 @@ distribution := $(shell dpkg-vendor --query Vendor)
 distrelease  := $(shell . /etc/os-release; echo $$VERSION_CODENAME)
 
 # required python3.x version
-UPSTRVER   := 3.12.1-2~
+UPSTRVER   := 3.12.7-1~
 
 # required versions of python3-lib2to3 and python3-distutils
-STDLIBVER   := 3.11.5-1~
+STDLIBVER   := 3.12.7-1~
 
 ifeq (,$(filter $(distrelease),lenny etch squeeze wheezy lucid maverick natty oneiric precise quantal raring saucy trusty))
-  bd_i586 = dpkg-dev (>= 1.17.11), python3.12:any (>= 3.12.1-2~),
+  bd_i586 = dpkg-dev (>= 1.17.11), python3.12:any (>= 3.12.7-1~),
 else
   bd_i586 = dpkg-dev (>= 1.16.1~),
 endif
@@ -63,7 +63,8 @@ stamp-doc-policy:
 	$(MAKE) -C policy singlehtml SPHINXOPTS='-D html_theme_options.nosidebar=true'
 	( \
 	    echo 'The HTML version of the Debian Python Policy can be found in the python3-dev package'; \
-	    html2text -utf8 -style pretty policy/_build/singlehtml/index.html; \
+	    html2text -utf8 -rcfile /usr/share/doc/html2text/examples/pretty.style \
+	    policy/_build/singlehtml/index.html; \
 	) > policy/_build/python-policy.txt
 	rm -rf policy/_build/singlehtml
 
@@ -175,7 +176,7 @@ stamp-dh_python:
 	dh_testdir
 	dh_testroot
 	dh_installdirs
-	#make check_versions
+	make check_versions
 	DESTDIR=debian/python3 PREFIX=/usr make install-dev
 	DESTDIR=debian/python3-minimal PREFIX=/usr make install-runtime
 ifeq ($(with_doc),yes)

--- a/debpython/files.py
+++ b/debpython/files.py
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 
 import logging
-from os import walk
+from os import environ, walk
 from os.path import abspath, isfile, join
 from subprocess import Popen, PIPE
 from debpython import PUBLIC_DIR_RE
@@ -46,12 +46,14 @@ def from_directory(dname, extensions=('.py',)):
 def from_package(package_name, extensions=('.py',)):
     """Generate *.py file names available in given package."""
     extensions = tuple(extensions)  # .endswith doesn't like list
+    env = environ.copy()
+    env["LC_ALL"] = "C.UTF-8"
     process = Popen(('/usr/bin/dpkg', '-L', package_name), stdout=PIPE,
-                         stderr=PIPE)
+                         stderr=PIPE, env=env)
     stdout, stderr = process.communicate()
     if process.returncode != 0:
         raise Exception("cannot get content of %s" % package_name)
-    stdout = str(stdout, 'utf-8')
+    stdout = stdout.decode('utf-8', errors='replace')
     for line in stdout.splitlines():
         if line.endswith(extensions):
             yield line

--- a/py3clean.rst
+++ b/py3clean.rst
@@ -19,7 +19,7 @@ OPTIONS
 
 -h, --help	show this help message and exit
 
--v, --verbose	turn verbose more one
+-v, --verbose	turn verbose mode on
 
 -q, --quiet	be quiet
 


### PR DESCRIPTION
* Update python3-supported-max (missed in 3.12.7-1).
* Add a check that python3-supported-(min|max) is correct.
* Re-enable check_versions at build time.